### PR TITLE
Make wall pieces uncraftable for Terrestria and Traverse woods

### DIFF
--- a/piecepacks/terrestria.json
+++ b/piecepacks/terrestria.json
@@ -14,7 +14,10 @@
 				"extrapieces:slab": "terrestria:redwood_slab",
 				"extrapieces:fence": "terrestria:redwood_fence",
 				"extrapieces:fence_gate": "terrestria:redwood_fence_gate"
-			}
+			},
+			"uncraftable": [
+				"extrapieces:wall"
+			]
 		},
 		"stripped_redwood_log": {
 			"base": "terrestria:stripped_redwood_log",
@@ -47,7 +50,10 @@
 				"extrapieces:slab": "terrestria:hemlock_slab",
 				"extrapieces:fence": "terrestria:hemlock_fence",
 				"extrapieces:fence_gate": "terrestria:hemlock_fence_gate"
-			}
+			},
+			"uncraftable": [
+				"extrapieces:wall"
+			]
 		},
 		"stripped_hemlock_log": {
 			"base": "terrestria:stripped_hemlock_log",
@@ -80,7 +86,10 @@
 				"extrapieces:slab": "terrestria:rubber_slab",
 				"extrapieces:fence": "terrestria:rubber_fence",
 				"extrapieces:fence_gate": "terrestria:rubber_fence_gate"
-			}
+			},
+			"uncraftable": [
+				"extrapieces:wall"
+			]
 		},
 		"stripped_rubber_log": {
 			"base": "terrestria:stripped_rubber_log",
@@ -113,7 +122,10 @@
 				"extrapieces:slab": "terrestria:cypress_slab",
 				"extrapieces:fence": "terrestria:cypress_fence",
 				"extrapieces:fence_gate": "terrestria:cypress_fence_gate"
-			}
+			},
+			"uncraftable": [
+				"extrapieces:wall"
+			]
 		},
 		"stripped_cypress_log": {
 			"base": "terrestria:stripped_cypress_log",
@@ -146,7 +158,10 @@
 				"extrapieces:slab": "terrestria:willow_slab",
 				"extrapieces:fence": "terrestria:willow_fence",
 				"extrapieces:fence_gate": "terrestria:willow_fence_gate"
-			}
+			},
+			"uncraftable": [
+				"extrapieces:wall"
+			]
 		},
 		"stripped_willow_log": {
 			"base": "terrestria:stripped_willow_log",
@@ -179,7 +194,10 @@
 				"extrapieces:slab": "terrestria:japanese_maple_slab",
 				"extrapieces:fence": "terrestria:japanese_maple_fence",
 				"extrapieces:fence_gate": "terrestria:japanese_maple_fence_gate"
-			}
+			},
+			"uncraftable": [
+				"extrapieces:wall"
+			]
 		},
 		"stripped_japanese_maple_log": {
 			"base": "terrestria:stripped_japanese_maple_log",
@@ -212,7 +230,10 @@
 				"extrapieces:slab": "terrestria:rainbow_eucalyptus_slab",
 				"extrapieces:fence": "terrestria:rainbow_eucalyptus_fence",
 				"extrapieces:fence_gate": "terrestria:rainbow_eucalyptus_fence_gate"
-			}
+			},
+			"uncraftable": [
+				"extrapieces:wall"
+			]
 		},
 		"stripped_rainbow_eucalyptus_log": {
 			"base": "terrestria:stripped_rainbow_eucalyptus_log",
@@ -239,7 +260,10 @@
 				"extrapieces:slab": "terrestria:sakura_slab",
 				"extrapieces:fence": "terrestria:sakura_fence",
 				"extrapieces:fence_gate": "terrestria:sakura_fence_gate"
-			}
+			},
+			"uncraftable": [
+				"extrapieces:wall"
+			]
 		},
 		"basalt": {
 			"base": "terrestria:basalt",

--- a/piecepacks/traverse.json
+++ b/piecepacks/traverse.json
@@ -14,7 +14,10 @@
 				"extrapieces:slab": "traverse:fir_slab",
 				"extrapieces:fence": "traverse:fir_fence",
 				"extrapieces:fence_gate": "traverse:fir_fence_gate"
-			}
+			},
+			"uncraftable": [
+				"extrapieces:wall"
+			]
 		},
 		"stripped_fir_log": {
 			"base": "traverse:stripped_fir_log",


### PR DESCRIPTION
This makes them match the vanilla pieceset behavior. (See also AllOfFabric/AOF-Normal#33)