### PR TITLE
Fix ModBlocks.init() calling finish() too early

### DIFF
--- a/src/main/java/com/shnupbups/extrapieces/register/ModBlocks.java
+++ b/src/main/java/com/shnupbups/extrapieces/register/ModBlocks.java
@@ -350,23 +350,13 @@ public class ModBlocks {
 					primedBuilders.add(setBuilders.get(id));
 				}
 			}
-		});
 
-		if (isDone()) {
-			ExtraPieces.log("Done! All sets built!");
-		} else {
-			// Exceptional condition...
-
-			for (PieceSet.Builder builder : setBuilders.values()) {
-				if (!builder.isBuilt()) {
-					ExtraPieces.log("Warning: Piece Set " + builder.name + " from Piece Pack " + builder.packName + " was not built!");
-				}
+			if (!finished && isDone()) {
+				ExtraPieces.log("Done! All sets built!");
+				finish(data);
+				ExtraPieces.log("Registered all PieceSets!");
 			}
-		}
-
-		finish(data);
-
-		ExtraPieces.log("Registered all PieceSets!");
+		});
 	}
 
 	public static void finish(ArtificeResourcePack.ServerResourcePackBuilder data) {


### PR DESCRIPTION
This caused issues with deferred piece sets as they wouldn't always have their data initialized.
(Example: missing recipes for oak plank sidings with Adorn's EP branch as that caused EP to defer the oak plank set)

I'm not sure where to put the warning code ("piece set x from piece pack y was not built") now. Maybe in `ModBlocks.isDone()` where it checks if the set hasn't been built?